### PR TITLE
Add Thread-ID to output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ fn main() {
     if args.len() > 2 {
         for (i, arg) in args[1..].iter().enumerate() {
             if arg == "-p" {
-                pid = Some(arg.parse().unwrap());
+                pid = Some(args[i+2].parse().unwrap());
             }
             else if arg == "--verbose" {
                 verbose_mode_enabled = true;


### PR DESCRIPTION
In my current workflow it helps me to have the Thread-ID present in the out to visually filter if I reached the right point.

Maybe it's helpful for others...